### PR TITLE
Refactor DataAccess and Services layers for public access

### DIFF
--- a/DataAccessLayer/AccountDAO.cs
+++ b/DataAccessLayer/AccountDAO.cs
@@ -1,7 +1,19 @@
-﻿namespace DataAccessLayer
+﻿using BusinessObjects;
+
+namespace DataAccessLayer
 {
     public class AccountDAO
     {
-
+        public static AccountMember GetAccountById(string accountID)
+        {
+            AccountMember accountMember = new AccountMember();
+            if (accountID.Equals("PS0001"))
+            {
+                accountMember.MemberId = accountID;
+                accountMember.MemberPassword = "123456";
+                accountMember.MemberRole = 1;
+            }
+            return accountMember;
+        }
     }
 }

--- a/DataAccessLayer/CategoryDAO.cs
+++ b/DataAccessLayer/CategoryDAO.cs
@@ -3,10 +3,41 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace DataAccessLayer
 {
-    internal class CategoryDAO
+    public class CategoryDAO
     {
+        public static List<Category> GetCategories()
+        {
+            Category beverager = new Category(1, "Beverages");
+            Category condiments = new Category(2, "Condiments");
+            Category confections = new Category(3, "Confections");
+            Category dairy = new Category(4, "Dairy Products");
+            Category grains = new Category(5, "Grains/Cereals");
+            Category meat = new Category(6, "Meat/Poultry");
+            Category produce = new Category(7, "Produce");
+            Category seafood = new Category(8, "Seafood");
+
+            var listCatergories = new List<Category>();
+            try
+            {
+                listCatergories.Add(beverager);
+                listCatergories.Add(condiments);
+                listCatergories.Add(confections);
+                listCatergories.Add(dairy);
+                listCatergories.Add(grains);
+                listCatergories.Add(meat);
+                listCatergories.Add(produce);
+                listCatergories.Add(seafood);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+            return listCatergories;
+
+        }
     }
 }

--- a/DataAccessLayer/DataAccessLayer.csproj
+++ b/DataAccessLayer/DataAccessLayer.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\BusinessObjects\BusinessObjects.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/DataAccessLayer/ProductDAO.cs
+++ b/DataAccessLayer/ProductDAO.cs
@@ -1,12 +1,88 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace DataAccessLayer
 {
-    internal class ProductDAO
+
+
+    public class ProductDAO
     {
+        private static List<Product> listProducts;
+
+        public ProductDAO()
+        {
+            Product chai = new Product(1, "Chai", 3, 12, 18);
+            Product chang = new Product(2, "Chang", 19, 17, 40);
+            Product aniseed = new Product(3, "Aniseed Syrup", 10, 13, 70);
+            listProducts = new List<Product> { chai, chang, aniseed };
+        }
+
+        public static List<Product> GetProducts()
+        {
+            return listProducts;
+        }
+
+        //public static List<Product> GetProducts()
+        //{ 
+        //    var listProducts = new List<Product>();
+        //    try
+        //    {
+        //        using var db = new MyStoreContext();
+        //        listProducts = db.Products.ToList();
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Console.WriteLine(ex.Message);
+        //    }
+        //    return listProducts;
+        //}
+
+        public static void SaveProduct(Product p)
+        {
+            listProducts.Add(p);
+        }
+
+        public static void UpdateProduct(Product product)
+        {
+            foreach (Product p in listProducts.ToList())
+            {
+                if(p.ProductId == product.ProductId)
+                {
+                    p.ProductName = product.ProductName;
+                    p.CategoryId = product.CategoryId;
+                    p.UnitInStock = product.UnitInStock;
+                    p.UnitPrice = product.UnitPrice;
+                    p.CategoryId = product.CategoryId;
+                }
+            }
+        }
+
+        public static void DeleteProduct(Product product)
+        {
+            foreach (Product p in listProducts.ToList())
+            {
+                if (p.ProductId == product.ProductId)
+                {
+                    listProducts.Remove(p);
+                }
+            }
+        }
+
+        public static Product GetProductById(int id)
+        {
+            foreach (Product p in listProducts.ToList())
+            {
+                if(p.ProductId == id)
+                {
+                    return p;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/Repositories/AccountRepository.cs
+++ b/Repositories/AccountRepository.cs
@@ -1,7 +1,10 @@
-﻿namespace Repositories
-{
-    public class AccountRepository
-    {
+﻿using BusinessObjects;
+using DataAccessLayer;
 
+namespace Repositories
+{
+    public class AccountRepository : IAccountRepository
+    {
+        public AccountMember GetAccountById(string accountID) => AccountDAO.GetAccountById(accountID);
     }
 }

--- a/Repositories/CategoryRepository.cs
+++ b/Repositories/CategoryRepository.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
+using DataAccessLayer;
 
 namespace Repositories
 {
-    internal class CategoryRepository
+    public class CategoryRepository : ICategoryRepository
     {
+        public List<Category> GetCategories() => CategoryDAO.GetCategories();
     }
 }

--- a/Repositories/IAccountRepository.cs
+++ b/Repositories/IAccountRepository.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace Repositories
 {
-    internal class IAccountRepository
+    public interface IAccountRepository
     {
+        AccountMember GetAccountById(string accountID);
     }
 }

--- a/Repositories/ICategoryRepository.cs
+++ b/Repositories/ICategoryRepository.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace Repositories
 {
-    internal class ICategoryRepository
+    public interface ICategoryRepository
     {
+        List<Category> GetCategories();
     }
 }

--- a/Repositories/IProductRepository.cs
+++ b/Repositories/IProductRepository.cs
@@ -3,10 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
+using DataAccessLayer;
 
 namespace Repositories
 {
-    internal class IProductRepository
+    public interface IProductRepository
     {
+        void SaveProduct(Product p);
+        void UpdateProduct(Product p);
+        void DeleteProduct(Product p);
+
+        List<Product> GetProducts();
+        Product GetProductById(int id);
     }
 }

--- a/Repositories/ProductRepository.cs
+++ b/Repositories/ProductRepository.cs
@@ -3,10 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
+using DataAccessLayer;
 
 namespace Repositories
 {
-    internal class ProductRepository
+    public class ProductRepository : IProductRepository
     {
+        public void DeleteProduct(Product p) => ProductDAO.DeleteProduct(p);
+
+        public Product GetProductById(int id) => ProductDAO.GetProductById(id);
+        public List<Product> GetProducts() => ProductDAO.GetProducts(); 
+
+        public void SaveProduct(Product p) => ProductDAO.SaveProduct(p);
+
+        public void UpdateProduct(Product p) => ProductDAO.UpdateProduct(p);
     }
 }

--- a/Repositories/Repositories.csproj
+++ b/Repositories/Repositories.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\BusinessObjects\BusinessObjects.csproj" />
+    <ProjectReference Include="..\DataAccessLayer\DataAccessLayer.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Services/AccountService.cs
+++ b/Services/AccountService.cs
@@ -1,7 +1,19 @@
-﻿namespace Services
-{
-    public class AccountService
-    {
+﻿using BusinessObjects;
+using Repositories;
 
+namespace Services
+{
+    public class AccountService : IAccountService
+    {
+        private readonly IAccountRepository iAccountRepository;
+
+        public AccountService()
+        {
+            iAccountRepository = new AccountRepository();
+        }
+        public AccountMember GetAccountById(string accountID)
+        {
+            return iAccountRepository.GetAccountById(accountID);
+        }
     }
 }

--- a/Services/CategoryService.cs
+++ b/Services/CategoryService.cs
@@ -1,12 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using BusinessObjects;
+using Repositories;
 
 namespace Services
 {
-    internal class CategoryService
+    public class CategoryService : ICategoryService
     {
+        private readonly ICategoryRepository iCategoryRepository;
+
+        public CategoryService()
+        {
+            iCategoryRepository = new CategoryRepository();
+        }
+
+        public List<Category> GetCategories()
+        {
+            return iCategoryRepository.GetCategories();
+        }
     }
 }

--- a/Services/IAccountService.cs
+++ b/Services/IAccountService.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace Services
 {
-    internal class IAccountService
+    public interface IAccountService
     {
+        AccountMember GetAccountById(string accountID);
     }
 }

--- a/Services/ICategoryService.cs
+++ b/Services/ICategoryService.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace Services
 {
-    internal class ICategoryService
+    public interface ICategoryService
     {
+        List<Category> GetCategories();
     }
 }

--- a/Services/IProductService.cs
+++ b/Services/IProductService.cs
@@ -3,10 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
 
 namespace Services
 {
-    internal class IProductService
+    public interface IProductService
     {
+        void SaveProduct(Product p);
+        void UpdateProduct(Product p);
+        void DeleteProduct(Product p);
+        List<Product> GetProducts();
+        Product GetProductById(int id);
     }
 }

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -3,10 +3,42 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BusinessObjects;
+using Repositories;
 
 namespace Services
 {
-    internal class ProductService
+    public class ProductService : IProductService
     {
+        private readonly IProductRepository iProductRepository;
+
+        public ProductService()
+        {
+            iProductRepository = new ProductRepository();
+        }
+        public void DeleteProduct(Product p)
+        {
+            iProductRepository.DeleteProduct(p);
+        }
+
+        public Product GetProductById(int id)
+        {
+            return iProductRepository.GetProductById(id);
+        }
+
+        public List<Product> GetProducts()
+        {
+            return iProductRepository.GetProducts();
+        }
+
+        public void SaveProduct(Product p)
+        {
+            iProductRepository.SaveProduct(p);
+        }
+
+        public void UpdateProduct(Product p)
+        {
+            iProductRepository.UpdateProduct(p);
+        }
     }
 }

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Repositories\Repositories.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This commit refactors several classes and interfaces in the DataAccessLayer and Services layers. Key changes include:

- Made `AccountDAO`, `CategoryDAO`, and `ProductDAO` public with new methods for account and category retrieval, and product management.
- Updated repository classes (`AccountRepository`, `CategoryRepository`, `ProductRepository`) to implement their respective interfaces.
- Made service classes (`AccountService`, `CategoryService`, `ProductService`) public and initialized their repositories.
- Updated interfaces (`IAccountRepository`, `ICategoryRepository`, `IProductRepository`, `IAccountService`, `ICategoryService`, `IProductService`) to public access with defined methods.
- Added project references to `BusinessObjects` and `DataAccessLayer` in project files for proper dependency management.